### PR TITLE
feat: add PBAC sample app with Carbon

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>PBAC Carbon Sample</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/index.tsx"></script>
+  </body>
+</html>

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  roots: ['<rootDir>/src'],
+  moduleFileExtensions: ['ts', 'tsx', 'js'],
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "pbac-carbon-sample",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "test": "jest"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.17.0",
+    "@carbon/react": "^1.40.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.2.0",
+    "ts-node": "^10.9.1",
+    "@types/react": "^18.0.28",
+    "@types/react-dom": "^18.0.11",
+    "vite": "^4.4.0",
+    "jest": "^29.6.2",
+    "ts-jest": "^29.1.1",
+    "@types/jest": "^29.5.2"
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
+import { SideNav, SideNavItems, SideNavLink } from '@carbon/react';
+import Projects from './modules/Projects';
+import Reports from './modules/Reports';
+import Users from './modules/Users';
+import Billing from './modules/Billing';
+import AuditLogs from './modules/AuditLogs';
+import SystemSettings from './modules/SystemSettings';
+import Forbidden from './components/403Page';
+import { usePermission } from './hooks/usePermission';
+
+type ProtectedProps = {
+  permission: string;
+  children: React.ReactElement;
+};
+
+const ProtectedRoute = ({ permission, children }: ProtectedProps) => {
+  const { hasPermission } = usePermission();
+  if (!hasPermission(permission)) {
+    return <Forbidden />;
+  }
+  return children;
+};
+
+export default function App() {
+  return (
+    <BrowserRouter>
+      <div style={{ display: 'flex' }}>
+        <SideNav expanded isFixedNav>
+          <SideNavItems>
+            <SideNavLink to="/projects">Projects</SideNavLink>
+            <SideNavLink to="/reports">Reports</SideNavLink>
+            <SideNavLink to="/users">Users</SideNavLink>
+            <SideNavLink to="/billing">Billing</SideNavLink>
+            <SideNavLink to="/audit">Audit Logs</SideNavLink>
+            <SideNavLink to="/settings">System Settings</SideNavLink>
+          </SideNavItems>
+        </SideNav>
+        <div style={{ marginLeft: '16rem', padding: '1rem', width: '100%' }}>
+          <Routes>
+            <Route path="/" element={<Navigate to="/projects" replace />} />
+            <Route path="/projects" element={<ProtectedRoute permission="project:view"><Projects /></ProtectedRoute>} />
+            <Route path="/reports" element={<ProtectedRoute permission="report:view"><Reports /></ProtectedRoute>} />
+            <Route path="/users" element={<ProtectedRoute permission="user:view"><Users /></ProtectedRoute>} />
+            <Route path="/billing" element={<ProtectedRoute permission="billing:view"><Billing /></ProtectedRoute>} />
+            <Route path="/audit" element={<ProtectedRoute permission="audit:view"><AuditLogs /></ProtectedRoute>} />
+            <Route path="/settings" element={<ProtectedRoute permission="system:manage"><SystemSettings /></ProtectedRoute>} />
+            <Route path="*" element={<Forbidden />} />
+          </Routes>
+        </div>
+      </div>
+    </BrowserRouter>
+  );
+}

--- a/src/__tests__/hasPermission.test.ts
+++ b/src/__tests__/hasPermission.test.ts
@@ -1,0 +1,33 @@
+import { evaluatePermission } from '../utils/hasPermission';
+import { PermissionCondition } from '../features/permissions';
+
+describe('hasPermission', () => {
+  const set = new Set(['project:view', 'project:edit', 'project:own', 'user:*']);
+
+  it('checks simple permission', () => {
+    expect(evaluatePermission('project:view', set)).toBe(true);
+  });
+
+  it('supports AND', () => {
+    const cond: PermissionCondition = { all: ['project:edit', 'project:own'] };
+    expect(evaluatePermission(cond, set)).toBe(true);
+  });
+
+  it('supports OR', () => {
+    const cond: PermissionCondition = { any: ['billing:update', 'project:view'] };
+    expect(evaluatePermission(cond, set)).toBe(true);
+  });
+
+  it('handles wildcard hierarchy', () => {
+    expect(evaluatePermission('user:edit', set)).toBe(true);
+  });
+
+  it('fails when missing', () => {
+    expect(evaluatePermission('billing:view', set)).toBe(false);
+  });
+
+  it('superuser', () => {
+    const superSet = new Set(['*']);
+    expect(evaluatePermission('billing:view', superSet)).toBe(true);
+  });
+});

--- a/src/components/403Page.tsx
+++ b/src/components/403Page.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Button } from '@carbon/react';
+import { useNavigate } from 'react-router-dom';
+
+const Forbidden = () => {
+  const navigate = useNavigate();
+  return (
+    <div style={{ padding: '2rem' }}>
+      <h1>403 - Forbidden</h1>
+      <Button onClick={() => navigate('/')}>Go Home</Button>
+    </div>
+  );
+};
+
+export default Forbidden;

--- a/src/components/PermissionProvider.tsx
+++ b/src/components/PermissionProvider.tsx
@@ -1,0 +1,39 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import { Permission, PermissionCondition } from '../features/permissions';
+import { evaluatePermission } from '../utils/hasPermission';
+
+type ContextType = {
+  permissions: Permission[];
+  loading: boolean;
+  hasPermission: (condition: PermissionCondition) => boolean;
+};
+
+const PermissionContext = createContext<ContextType>({
+  permissions: [],
+  loading: true,
+  hasPermission: () => false,
+});
+
+export const PermissionProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [permissions, setPermissions] = useState<Permission[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    // simulate async fetch
+    setTimeout(() => {
+      setPermissions(['project:view', 'report:view', 'user:*']);
+      setLoading(false);
+    }, 500);
+  }, []);
+
+  const hasPermission = (condition: PermissionCondition) =>
+    evaluatePermission(condition, new Set(permissions));
+
+  return (
+    <PermissionContext.Provider value={{ permissions, loading, hasPermission }}>
+      {children}
+    </PermissionContext.Provider>
+  );
+};
+
+export const usePermissionContext = () => useContext(PermissionContext);

--- a/src/components/PermissionWrapper.tsx
+++ b/src/components/PermissionWrapper.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { PermissionCondition } from '../features/permissions';
+import { usePermission } from '../hooks/usePermission';
+
+interface Props {
+  condition: PermissionCondition;
+  fallback?: React.ReactNode;
+  children: React.ReactNode;
+}
+
+export const PermissionWrapper: React.FC<Props> = ({ condition, fallback = null, children }) => {
+  const { hasPermission } = usePermission();
+  if (!hasPermission(condition)) {
+    return <>{fallback}</>;
+  }
+  return <>{children}</>;
+};

--- a/src/features/permissions.ts
+++ b/src/features/permissions.ts
@@ -1,0 +1,19 @@
+export type Permission =
+  | 'project:view'
+  | 'project:edit'
+  | 'project:own'
+  | 'report:view'
+  | 'report:approve'
+  | 'audit:view'
+  | 'user:view'
+  | 'user:edit'
+  | 'user:create'
+  | 'user:*'
+  | 'billing:view'
+  | 'billing:update'
+  | 'system:manage'
+  | '*';
+
+export type PermissionCondition =
+  | Permission
+  | { all?: PermissionCondition[]; any?: PermissionCondition[] };

--- a/src/features/roles.ts
+++ b/src/features/roles.ts
@@ -1,0 +1,7 @@
+export type Role = 'admin' | 'editor' | 'viewer';
+
+export const rolePermissions: Record<Role, import('./permissions').Permission[]> = {
+  admin: ['*'],
+  editor: ['project:view', 'project:edit', 'user:view', 'user:edit', 'user:create'],
+  viewer: ['project:view', 'user:view'],
+};

--- a/src/hooks/usePermission.ts
+++ b/src/hooks/usePermission.ts
@@ -1,0 +1,7 @@
+import { PermissionCondition } from '../features/permissions';
+import { usePermissionContext } from '../components/PermissionProvider';
+
+export const usePermission = () => {
+  const { loading, hasPermission } = usePermissionContext();
+  return { loading, hasPermission: (cond: PermissionCondition) => hasPermission(cond) };
+};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import { PermissionProvider } from './components/PermissionProvider';
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <PermissionProvider>
+      <App />
+    </PermissionProvider>
+  </React.StrictMode>
+);

--- a/src/modules/AuditLogs.tsx
+++ b/src/modules/AuditLogs.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { PermissionWrapper } from '../components/PermissionWrapper';
+
+export default function AuditLogs() {
+  return (
+    <PermissionWrapper condition="audit:view" fallback={<div>No access to audit logs</div>}>
+      <div>Audit logs table</div>
+    </PermissionWrapper>
+  );
+}

--- a/src/modules/Billing.tsx
+++ b/src/modules/Billing.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Tabs, Tab, Button } from '@carbon/react';
+import { PermissionWrapper } from '../components/PermissionWrapper';
+
+export default function Billing() {
+  return (
+    <Tabs>
+      <Tab id="billing-overview" label="Overview">
+        Billing overview
+      </Tab>
+      <PermissionWrapper condition="billing:update">
+        <Tab id="billing-update" label="Update">
+          <Button kind="danger">Update Billing</Button>
+        </Tab>
+      </PermissionWrapper>
+    </Tabs>
+  );
+}

--- a/src/modules/Projects.tsx
+++ b/src/modules/Projects.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import {
+  Tabs,
+  Tab,
+  DataTable,
+  Button,
+  OverflowMenu,
+  OverflowMenuItem,
+  TableContainer,
+  Table,
+  TableHead,
+  TableRow,
+  TableHeader,
+  TableBody,
+  TableCell,
+  TableToolbar,
+  TableToolbarContent,
+  TableToolbarSearch,
+} from '@carbon/react';
+import { PermissionWrapper } from '../components/PermissionWrapper';
+
+const rows = [
+  { id: '1', name: 'Project A', owner: 'me' },
+  { id: '2', name: 'Project B', owner: 'other' },
+];
+
+const headers = [
+  { key: 'name', header: 'Name' },
+  { key: 'owner', header: 'Owner' },
+];
+
+export default function Projects() {
+  return (
+    <Tabs>
+      <Tab id="projects-overview" label="Overview">
+        <DataTable rows={rows} headers={headers}>
+          {({ rows, headers, getHeaderProps, getRowProps, getTableProps }) => (
+            <TableContainer>
+              <TableToolbar>
+                <TableToolbarContent>
+                  <TableToolbarSearch />
+                  <PermissionWrapper
+                    condition="project:create"
+                    fallback={<Button disabled title="Missing permission">Create</Button>}
+                  >
+                    <Button kind="primary">Create</Button>
+                  </PermissionWrapper>
+                </TableToolbarContent>
+              </TableToolbar>
+              <Table {...getTableProps()}>
+                <TableHead>
+                  <TableRow>
+                    {headers.map((header) => (
+                      <TableHeader key={header.key} {...getHeaderProps({ header })}>
+                        {header.header}
+                      </TableHeader>
+                    ))}
+                    <TableHeader>Actions</TableHeader>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {rows.map((row) => (
+                    <TableRow key={row.id} {...getRowProps({ row })}>
+                      {row.cells.map((cell) => (
+                        <TableCell key={cell.id}>{cell.value}</TableCell>
+                      ))}
+                      <TableCell>
+                        <OverflowMenu>
+                          <PermissionWrapper
+                            condition={{ all: ['project:edit', 'project:own'] }}
+                          >
+                            <OverflowMenuItem itemText="Edit" />
+                          </PermissionWrapper>
+                          <PermissionWrapper condition="project:delete">
+                            <OverflowMenuItem itemText="Delete" />
+                          </PermissionWrapper>
+                        </OverflowMenu>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          )}
+        </DataTable>
+      </Tab>
+      <PermissionWrapper condition="project:analytics">
+        <Tab id="projects-analytics" label="Analytics">
+          Analytics content
+        </Tab>
+      </PermissionWrapper>
+    </Tabs>
+  );
+}

--- a/src/modules/Reports.tsx
+++ b/src/modules/Reports.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Tabs, Tab } from '@carbon/react';
+import { PermissionWrapper } from '../components/PermissionWrapper';
+
+export default function Reports() {
+  return (
+    <PermissionWrapper
+      condition={{ any: ['report:view', { all: ['audit:view', 'report:approve'] }] }}
+      fallback={<div>Missing permission to view reports</div>}
+    >
+      <Tabs>
+        <Tab id="reports-overview" label="Overview">Reports overview</Tab>
+        <PermissionWrapper condition="report:approve">
+          <Tab id="reports-approve" label="Approvals">Approval queue</Tab>
+        </PermissionWrapper>
+      </Tabs>
+    </PermissionWrapper>
+  );
+}

--- a/src/modules/SystemSettings.tsx
+++ b/src/modules/SystemSettings.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Tabs, Tab } from '@carbon/react';
+import { PermissionWrapper } from '../components/PermissionWrapper';
+
+export default function SystemSettings() {
+  return (
+    <PermissionWrapper condition="system:manage" fallback={<div>Settings unavailable</div>}>
+      <Tabs>
+        <Tab id="settings-general" label="General">
+          General settings
+        </Tab>
+        <PermissionWrapper condition="system:advanced">
+          <Tab id="settings-advanced" label="Advanced">
+            Advanced settings
+          </Tab>
+        </PermissionWrapper>
+      </Tabs>
+    </PermissionWrapper>
+  );
+}

--- a/src/modules/Users.tsx
+++ b/src/modules/Users.tsx
@@ -1,0 +1,100 @@
+import React, { useState } from 'react';
+import {
+  DataTable,
+  Table,
+  TableHead,
+  TableRow,
+  TableHeader,
+  TableBody,
+  TableCell,
+  Button,
+  Modal,
+  Select,
+  SelectItem,
+  TextInput,
+} from '@carbon/react';
+import { PermissionWrapper } from '../components/PermissionWrapper';
+import { getUsers, addUser, UserRecord } from '../utils/usersDb';
+import { Role } from '../features/roles';
+
+export default function Users() {
+  const [users, setUsers] = useState<UserRecord[]>(getUsers());
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState('');
+  const [role, setRole] = useState<Role>('viewer');
+
+  const handleAdd = () => {
+    if (!name) return;
+    addUser(name, role);
+    setUsers(getUsers());
+    setOpen(false);
+    setName('');
+    setRole('viewer');
+  };
+
+  return (
+    <PermissionWrapper condition="user:view" fallback={<div>No access to users</div>}>
+      <h2>Users</h2>
+      <PermissionWrapper
+        condition="user:create"
+        fallback={<Button disabled title="Need user:create">New User</Button>}
+      >
+        <Button onClick={() => setOpen(true)}>New User</Button>
+      </PermissionWrapper>
+      <DataTable
+        rows={users.map((u) => ({ id: u.id, name: u.name, role: u.role }))}
+        headers={[
+          { key: 'name', header: 'Name' },
+          { key: 'role', header: 'Role' },
+        ]}
+      >
+        {({ rows, headers, getHeaderProps, getRowProps }) => (
+          <Table>
+            <TableHead>
+              <TableRow>
+                {headers.map((header) => (
+                  <TableHeader {...getHeaderProps({ header })}>
+                    {header.header}
+                  </TableHeader>
+                ))}
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {rows.map((row) => (
+                <TableRow {...getRowProps({ row })}>
+                  {row.cells.map((cell) => (
+                    <TableCell key={cell.id}>{cell.value}</TableCell>
+                  ))}
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </DataTable>
+      <Modal
+        open={open}
+        modalHeading="Create User"
+        primaryButtonText="Create"
+        onRequestClose={() => setOpen(false)}
+        onRequestSubmit={handleAdd}
+      >
+        <TextInput
+          id="name"
+          labelText="Name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+        <Select
+          id="role"
+          labelText="Role"
+          value={role}
+          onChange={(e) => setRole(e.target.value as Role)}
+        >
+          <SelectItem value="viewer" text="viewer" />
+          <SelectItem value="editor" text="editor" />
+          <SelectItem value="admin" text="admin" />
+        </Select>
+      </Modal>
+    </PermissionWrapper>
+  );
+}

--- a/src/utils/hasPermission.ts
+++ b/src/utils/hasPermission.ts
@@ -1,0 +1,29 @@
+import { Permission, PermissionCondition } from '../features/permissions';
+
+const matches = (have: Permission, need: string) => {
+  if (have === '*' || have === need) return true;
+  if (have.endsWith('*')) {
+    const prefix = have.replace('*', '');
+    return need.startsWith(prefix);
+  }
+  return false;
+};
+
+export const evaluatePermission = (
+  condition: PermissionCondition,
+  set: Set<Permission>
+): boolean => {
+  if (typeof condition === 'string') {
+    for (const perm of set) {
+      if (matches(perm, condition)) return true;
+    }
+    return false;
+  }
+  if (condition.all) {
+    return condition.all.every((c) => evaluatePermission(c, set));
+  }
+  if (condition.any) {
+    return condition.any.some((c) => evaluatePermission(c, set));
+  }
+  return false;
+};

--- a/src/utils/usersDb.ts
+++ b/src/utils/usersDb.ts
@@ -1,0 +1,35 @@
+import { Role } from '../features/roles';
+
+export type UserRecord = { id: string; name: string; role: Role };
+
+const STORAGE_KEY = 'pbac_users';
+
+const load = (): UserRecord[] => {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as UserRecord[]) : [];
+  } catch {
+    return [];
+  }
+};
+
+const save = (users: UserRecord[]) => {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(users));
+};
+
+export const getUsers = (): UserRecord[] => load();
+
+export const addUser = (name: string, role: Role) => {
+  const users = load();
+  users.push({ id: Date.now().toString(), name, role });
+  save(users);
+};
+
+export const updateUserRole = (id: string, role: Role) => {
+  const users = load();
+  const idx = users.findIndex((u) => u.id === id);
+  if (idx >= 0) {
+    users[idx].role = role;
+    save(users);
+  }
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "jsx": "react-jsx",
+    "moduleResolution": "Node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "baseUrl": "./src"
+  },
+  "include": ["src"],
+  "exclude": ["node_modules"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- scaffold TypeScript React app using IBM Carbon components
- implement composable permission checks with hierarchical support
- add sample modules showing worst-case PBAC scenarios
- enable local user creation and role assignment stored on localhost

## Testing
- `npm install` (fails: 403 Forbidden - GET https://registry.npmjs.org/@carbon%2freact)
- `npm test` (fails: sh: 1: jest: not found)


------
https://chatgpt.com/codex/tasks/task_e_68938aab51548333b62ca9620d24c885